### PR TITLE
Making callbacks the last parameter + jsbeautifer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,36 +1,48 @@
-module.exports = function(grunt) {
-  grunt.initConfig({
-    simplemocha: {
-      options: {
-        globals: ['should'],
-        timeout: 3000,
-        ignoreLeaks: false,
-        ui: 'bdd',
-        reporter: 'list'
-      },
-      all: { src: ['test/**/*.js'] }
-    },
+module.exports = function (grunt) {
+    grunt.initConfig({
+        simplemocha: {
+            options: {
+                globals: ['should'],
+                timeout: 3000,
+                ignoreLeaks: false,
+                ui: 'bdd',
+                reporter: 'list'
+            },
+            all: {
+                src: ['test/**/*.js']
+            }
+        },
 
-    jshint: {
-      options: {
-        laxbreak: true
-      },
-      all: [ 'Gruntfile.js', 'index.js', 'lib/**/*.js', 'test/**/*.js']
-    },
+        jsbeautifier: {
+            files: ['Gruntfile.js', 'index.js', 'lib/**/*.js', 'test/**/*.js'],
+            options: {
+                js: {
+                    jslintHappy: true
+                }
+            }
+        },
 
-    jsdoc: {
-      all: {
-        src: ['index.js', 'lib/**/*.js'],
-        dest: 'doc'
-      }
-    }
-  });
+        jshint: {
+            options: {
+                laxbreak: true
+            },
+            all: ['Gruntfile.js', 'index.js', 'lib/**/*.js', 'test/**/*.js']
+        },
 
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-simple-mocha');
-  grunt.loadNpmTasks('grunt-jsdoc');
+        jsdoc: {
+            all: {
+                src: ['index.js', 'lib/**/*.js'],
+                dest: 'doc'
+            }
+        }
+    });
 
-  grunt.registerTask('test', ['simplemocha:all']);
-  grunt.registerTask('build', ['jshint', 'test']);
-  grunt.registerTask('default', ['build', 'jsdoc']);
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-jsbeautifier');
+    grunt.loadNpmTasks('grunt-simple-mocha');
+    grunt.loadNpmTasks('grunt-jsdoc');
+
+    grunt.registerTask('test', ['simplemocha:all']);
+    grunt.registerTask('build', ['jsbeautifier', 'jshint', 'test']);
+    grunt.registerTask('default', ['build', 'jsdoc']);
 };

--- a/README.md
+++ b/README.md
@@ -16,34 +16,29 @@ var Bing = require('node-bing-api')({ accKey: "your-account-key" });
 
 #### Web Search:
 ```js
-Bing.web("Pizza", function(error, res, body){
-    console.log(body);
-  },
-  {
+Bing.web("Pizza", {
     top: 10,  // Number of results (max 50)
     skip: 3,   // Skip first 3 results
+  }, function(error, res, body){
+    console.log(body);
   });
 ```
 
 #### Composite Search:
 ```js
-Bing.composite("xbox", function(error, res, body){
-    console.log(body);
-  },
-  {
+Bing.composite("xbox", {
     top: 10,  // Number of results (max 50)
     skip: 3,   // Skip first 3 results
     sources: "web+news", //Choises are web+image+video+news+spell
     newssortby: "Date" //Choices are Date, Relevance
+  }, function(error, res, body){
+    console.log(body);
   });
 ```
 
 #### News Search:
 ```js
-Bing.news("xbox", function(error, res, body){
-    console.log(body);
-  },
-  {
+Bing.news("xbox", {
     top: 10,  // Number of results (max 50)
     skip: 3,   // Skip first 3 results
     newssortby: "Date" //Choices are: Date, Relevance
@@ -56,40 +51,40 @@ Bing.news("xbox", function(error, res, body){
                                 //   rt_US
                                 //   rt_World
                                 //   rt_ScienceAndTechnology
+  }, function(error, res, body){
+    console.log(body);
   });
 ```
 
 #### Video Search:
 ```js
-Bing.video("monkey vs frog", function(error, res, body){
-    console.log(body);
-  },
-  {
+Bing.video("monkey vs frog", {
     top: 10,  // Number of results (max 50)
     skip: 3,   // Skip first 3 result
     videofilters: {
       duration: 'short',
-      resolution: 'high' 
+      resolution: 'high'
     }
+  }, function(error, res, body){
+    console.log(body);
   });
 ```
 
 #### Images Search:
 ```js
-Bing.images("Ninja Turtles", function(error, res, body){
+Bing.images("Ninja Turtles", {skip: 50}, function(error, res, body){
   console.log(body);
-}, {skip: 50});
+});
 ```
 Adding filter(s) for the Image Search
 ```js
-Bing.images("Ninja Turtles", function(error, res, body){
-  console.log(body);
-  }, 
-  {
+Bing.images("Ninja Turtles", {
     imagefilters: {
       size: 'small',
-      color: 'monochrome' 
+      color: 'monochrome'
     }
+  }, function(error, res, body){
+  console.log(body);
   });
 ```
 Accepted filter values:
@@ -105,18 +100,18 @@ Accepted filter values:
 #### Specify Market
 Getting spanish results:
 ```js
-Bing.images("Ninja Turtles", function(error, res, body){
+Bing.images("Ninja Turtles", {top: 5, market: 'es-ES'}, function(error, res, body){
   console.log(body);
-}, {top: 5, market: 'es-ES'});
+});
 ```
 [List of Bing Markets](https://msdn.microsoft.com/en-us/library/dd251064.aspx)
 
 
 #### Adult Filter
 ```js
-Bing.images('Kim Kardashian', function(error, res, body){
+Bing.images('Kim Kardashian', {market: 'en-US', adult: 'Strict'}, function(error, res, body){
   console.log(body.d.results);
-}, { market: 'en-US', adult: 'Strict'});
+});
 ```
 Accepted values: "Off", "Moderate", "Strict".
 
@@ -126,4 +121,3 @@ or videos, but may include sexually explicit text.*
 
 ## License
 MIT
-

--- a/lib/bing.js
+++ b/lib/bing.js
@@ -1,4 +1,3 @@
-
 /*********************************************************
  *  Simple Node.js module for using the Bing Search API  *
  *********************************************************/
@@ -15,96 +14,83 @@ var request = require('request'),
  * @returns {Bing}
  * @constructor
  */
-var Bing = function( options ) {
+var Bing = function (options) {
 
-  if( !(this instanceof Bing) ) return new Bing( options );
+    if (!(this instanceof Bing)) return new Bing(options);
 
-  var defaults = {
+    var defaults = {
 
-    //Bing Search API URI
-    rootUri: "https://api.datamarket.azure.com/Bing/Search/v1/",
+        //Bing Search API URI
+        rootUri: "https://api.datamarket.azure.com/Bing/Search/v1/",
 
-    //Account Key
-    accKey: null,
+        //Account Key
+        accKey: null,
 
-    //Bing UserAgent
-    userAgent: 'Bing Search Client for Node.js',
+        //Bing UserAgent
+        userAgent: 'Bing Search Client for Node.js',
 
-    //Request Timeout
-    reqTimeout: 5000,
+        //Request Timeout
+        reqTimeout: 5000,
 
-    // Number of results (limited to 50 by API)
-    top: 50,
+        // Number of results (limited to 50 by API)
+        top: 50,
 
-    // Number of skipped results (pagination)
-    skip: 0
+        // Number of skipped results (pagination)
+        skip: 0
 
-  };
+    };
 
-  //merge options passed in with defaults
-  this.options = _.extend(defaults, options);
+    //merge options passed in with defaults
+    this.options = _.extend(defaults, options);
 
-  this.searchVertical = function(query, vertical, options, callback) {
-    if (typeof options === 'function') {
-        callback = options;
-    }
-    if(typeof callback != 'function') {
-      throw "Error: Callback function required!";
-    }
+    this.searchVertical = function (query, vertical, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+        }
+        if (typeof callback != 'function') {
+            throw "Error: Callback function required!";
+        }
 
-    // Create a copy of the options, to avoid permanent overwrites
-    var opts = JSON.parse(JSON.stringify(this.options));
+        // Create a copy of the options, to avoid permanent overwrites
+        var opts = JSON.parse(JSON.stringify(this.options));
 
-    if (typeof options === 'object') {
-        _.extend(opts, options);
-    }
+        if (typeof options === 'object') {
+            _.extend(opts, options);
+        }
 
-    var reqUri = opts.rootUri
-                   + vertical
-                   + "?$format=json&"
-                   + qs.stringify({ "Query": "'" + query + "'" })
-                   + "&$top=" + opts.top
-                   + "&$skip=" + opts.skip
-                   + (opts.sources ? "&Sources=%27" + opts.sources + "%27" : '')
-                   + (opts.newssortby ? "&NewsSortBy=%27" + opts.newssortby + "%27" : '')
-                   + (opts.newscategory ? "&NewsCategory=%27" + opts.newscategory + "%27" : '')
-                   + (opts.newslocationoverride ? "&NewsLocationOverride=%27" + opts.newslocationoverride + "%27" : '')
-                   + (opts.market ? "&Market=%27" + opts.market + "%27" : '')
-                   + (opts.adult  ? "&Adult=%27"  + opts.adult  + "%27" : '')
-                   + (opts.imagefilters
-                       ? '&' + qs.stringify({ "ImageFilters": "'" + opts.imagefilters + "'" })
-                       : '')
-                   + (opts.videofilters
-                     ? '&' + qs.stringify({ "VideoFilters": "'" + opts.videofilters + "'" })
-                     : '');
+        var reqUri = opts.rootUri + vertical + "?$format=json&" + qs.stringify({
+            "Query": "'" + query + "'"
+        }) + "&$top=" + opts.top + "&$skip=" + opts.skip + (opts.sources ? "&Sources=%27" + opts.sources + "%27" : '') + (opts.newssortby ? "&NewsSortBy=%27" + opts.newssortby + "%27" : '') + (opts.newscategory ? "&NewsCategory=%27" + opts.newscategory + "%27" : '') + (opts.newslocationoverride ? "&NewsLocationOverride=%27" + opts.newslocationoverride + "%27" : '') + (opts.market ? "&Market=%27" + opts.market + "%27" : '') + (opts.adult ? "&Adult=%27" + opts.adult + "%27" : '') + (opts.imagefilters ? '&' + qs.stringify({
+            "ImageFilters": "'" + opts.imagefilters + "'"
+        }) : '') + (opts.videofilters ? '&' + qs.stringify({
+            "VideoFilters": "'" + opts.videofilters + "'"
+        }) : '');
 
-    request({
-      uri: reqUri,
-      method: opts.method || "GET",
-      headers: {
-        "User-Agent": opts.userAgent
-      },
-      auth: {
-        user: opts.accKey,
-        pass: opts.accKey
-      },
-      timeout: opts.reqTimeout
+        request({
+            uri: reqUri,
+            method: opts.method || "GET",
+            headers: {
+                "User-Agent": opts.userAgent
+            },
+            auth: {
+                user: opts.accKey,
+                pass: opts.accKey
+            },
+            timeout: opts.reqTimeout
 
-    }, function(err, res, body){
+        }, function (err, res, body) {
 
-      if(res && res.statusCode !== 200){
-        err = new Error(body);
-      }else{
+            if (res && res.statusCode !== 200) {
+                err = new Error(body);
+            } else {
 
-        // Parse body, if body
-        body = typeof body === 'string'
-                 ? JSON.parse(body)
-                 : body;
-      }
+                // Parse body, if body
+                body = typeof body === 'string' ? JSON.parse(body) : body;
+            }
 
-      callback(err, res, body);
-    });
-  };
+            callback(err, res, body);
+        });
+    };
 
 };
 
@@ -131,7 +117,7 @@ var Bing = function( options ) {
  *
  * @function
  */
-Bing.prototype.web = function(query, options, callback) {
+Bing.prototype.web = function (query, options, callback) {
     this.searchVertical(query, "Web", options, callback);
 };
 
@@ -153,8 +139,8 @@ Bing.prototype.search = Bing.prototype.web;
  *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.composite = function(query, options, callback) {
-  this.searchVertical(query, "Composite", options, callback);
+Bing.prototype.composite = function (query, options, callback) {
+    this.searchVertical(query, "Composite", options, callback);
 };
 
 /**
@@ -170,8 +156,8 @@ Bing.prototype.composite = function(query, options, callback) {
  *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.news = function(query, options, callback) {
-  this.searchVertical(query, "News", options, callback);
+Bing.prototype.news = function (query, options, callback) {
+    this.searchVertical(query, "News", options, callback);
 };
 
 /**
@@ -187,22 +173,19 @@ Bing.prototype.news = function(query, options, callback) {
  *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.video = function(query, options, callback) {
-  if (options
-    && typeof options === 'object'
-    && options.videofilters
-    && typeof options.videofilters === 'object') {
-    var filterQuery = '';
-    var filters = Object.keys(options.videofilters);
-    filters.map(function(key, i) {
-      filterQuery += capitalizeFirstLetter(key) + ':';
-      filterQuery += capitalizeFirstLetter(options.videofilters[key]);
-      if (i < filters.length - 1)
-        filterQuery += '+';
-    });
-    options.videofilters = filterQuery;
-  }
-  this.searchVertical(query, "Video", options, callback);
+Bing.prototype.video = function (query, options, callback) {
+    if (options && typeof options === 'object' && options.videofilters && typeof options.videofilters === 'object') {
+        var filterQuery = '';
+        var filters = Object.keys(options.videofilters);
+        filters.map(function (key, i) {
+            filterQuery += capitalizeFirstLetter(key) + ':';
+            filterQuery += capitalizeFirstLetter(options.videofilters[key]);
+            if (i < filters.length - 1)
+                filterQuery += '+';
+        });
+        options.videofilters = filterQuery;
+    }
+    this.searchVertical(query, "Video", options, callback);
 };
 
 
@@ -221,26 +204,23 @@ Bing.prototype.video = function(query, options, callback) {
  *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.images = function(query, options, callback) {
-    if (options
-        && typeof options === 'object'
-        && options.imagefilters
-        && typeof options.imagefilters === 'object') {
-      var filterQuery = '';
-      var filters = Object.keys(options.imagefilters);
-      filters.map(function(key, i) {
-        filterQuery += capitalizeFirstLetter(key) + ':';
-        filterQuery += capitalizeFirstLetter(options.imagefilters[key]);
-        if (i < filters.length - 1)
-          filterQuery += '+';
-      });
-      options.imagefilters = filterQuery;
+Bing.prototype.images = function (query, options, callback) {
+    if (options && typeof options === 'object' && options.imagefilters && typeof options.imagefilters === 'object') {
+        var filterQuery = '';
+        var filters = Object.keys(options.imagefilters);
+        filters.map(function (key, i) {
+            filterQuery += capitalizeFirstLetter(key) + ':';
+            filterQuery += capitalizeFirstLetter(options.imagefilters[key]);
+            if (i < filters.length - 1)
+                filterQuery += '+';
+        });
+        options.imagefilters = filterQuery;
     }
     this.searchVertical(query, "Image", options, callback);
 };
 
 function capitalizeFirstLetter(s) {
-  return s.charAt(0).toUpperCase() + s.slice(1);
+    return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
 module.exports = Bing;

--- a/lib/bing.js
+++ b/lib/bing.js
@@ -44,8 +44,10 @@ var Bing = function( options ) {
   //merge options passed in with defaults
   this.options = _.extend(defaults, options);
 
-  this.searchVertical = function(query, vertical, callback, options) {
-
+  this.searchVertical = function(query, vertical, options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+    }
     if(typeof callback != 'function') {
       throw "Error: Callback function required!";
     }
@@ -53,7 +55,9 @@ var Bing = function( options ) {
     // Create a copy of the options, to avoid permanent overwrites
     var opts = JSON.parse(JSON.stringify(this.options));
 
-    _.extend(opts, options);
+    if (typeof options === 'object') {
+        _.extend(opts, options);
+    }
 
     var reqUri = opts.rootUri
                    + vertical
@@ -67,7 +71,7 @@ var Bing = function( options ) {
                    + (opts.newslocationoverride ? "&NewsLocationOverride=%27" + opts.newslocationoverride + "%27" : '')
                    + (opts.market ? "&Market=%27" + opts.market + "%27" : '')
                    + (opts.adult  ? "&Adult=%27"  + opts.adult  + "%27" : '')
-                   + (opts.imagefilters 
+                   + (opts.imagefilters
                        ? '&' + qs.stringify({ "ImageFilters": "'" + opts.imagefilters + "'" })
                        : '')
                    + (opts.videofilters
@@ -118,16 +122,17 @@ var Bing = function( options ) {
  *
  * @param {String} query              Query term to search for.
  *
- * @param {requestCallback} callback  Callback called with (potentially
- *                                    json-parsed) response.
- *
  * @param {Object} options            Options to command, allows overriding
  *                                    of rootUri, accKey (Bing API key),
  *                                    userAgent, reqTimeout, top, skip
+ *
+ * @param {requestCallback} callback  Callback called with (potentially
+ *                                    json-parsed) response.
+ *
  * @function
  */
-Bing.prototype.web = function(query, callback, options) {
-    this.searchVertical(query, "Web", callback, options);
+Bing.prototype.web = function(query, options, callback) {
+    this.searchVertical(query, "Web", options, callback);
 };
 
 // Alias Bing.search to Bing.web
@@ -140,16 +145,16 @@ Bing.prototype.search = Bing.prototype.web;
  *
  * @param {String} query              Query term to search for.
  *
- * @param {requestCallback} callback  Callback called with (potentially
- *                                    json-parsed) response.
- *
  * @param {Object} options            Options to command, allows overriding
  *                                    of rootUri, accKey (Bing API key),
  *                                    userAgent, reqTimeout, top, skip,
+ *
+ * @param {requestCallback} callback  Callback called with (potentially
+ *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.composite = function(query, callback, options) {
-  this.searchVertical(query, "Composite", callback, options);
+Bing.prototype.composite = function(query, options, callback) {
+  this.searchVertical(query, "Composite", options, callback);
 };
 
 /**
@@ -157,16 +162,16 @@ Bing.prototype.composite = function(query, callback, options) {
  *
  * @param {String} query              Query term to search for.
  *
- * @param {requestCallback} callback  Callback called with (potentially
- *                                    json-parsed) response.
- *
  * @param {Object} options            Options to command, allows overriding
  *                                    of rootUri, accKey (Bing API key),
  *                                    userAgent, reqTimeout, top, skip,
+ *
+ * @param {requestCallback} callback  Callback called with (potentially
+ *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.news = function(query, callback, options) {
-  this.searchVertical(query, "News", callback, options);
+Bing.prototype.news = function(query, options, callback) {
+  this.searchVertical(query, "News", options, callback);
 };
 
 /**
@@ -174,16 +179,17 @@ Bing.prototype.news = function(query, callback, options) {
  *
  * @param {String} query              Query term to search for.
  *
- * @param {requestCallback} callback  Callback called with (potentially
- *                                    json-parsed) response.
- *
  * @param {Object} options            Options to command, allows overriding
  *                                    of rootUri, accKey (Bing API key),
  *                                    userAgent, reqTimeout, top, skip,
+ *
+ * @param {requestCallback} callback  Callback called with (potentially
+ *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.video = function(query, callback, options) {
+Bing.prototype.video = function(query, options, callback) {
   if (options
+    && typeof options === 'object'
     && options.videofilters
     && typeof options.videofilters === 'object') {
     var filterQuery = '';
@@ -196,7 +202,7 @@ Bing.prototype.video = function(query, callback, options) {
     });
     options.videofilters = filterQuery;
   }
-  this.searchVertical(query, "Video", callback, options);
+  this.searchVertical(query, "Video", options, callback);
 };
 
 
@@ -206,18 +212,19 @@ Bing.prototype.video = function(query, callback, options) {
  *
  * @param {String} query              Query term to search for.
  *
- * @param {requestCallback} callback  Callback called with (potentially
- *                                    json-parsed) response.
- *
  * @param {Object} options            Options to command, allows overriding of
  *                                    rootUri, accKey (Bing API key),
  *                                    userAgent, reqTimeout, top, skip,
  *                                    imagefilters
+ *
+ * @param {requestCallback} callback  Callback called with (potentially
+ *                                    json-parsed) response.
  * @function
  */
-Bing.prototype.images = function(query, callback, options) {
-    if (options 
-        && options.imagefilters 
+Bing.prototype.images = function(query, options, callback) {
+    if (options
+        && typeof options === 'object'
+        && options.imagefilters
         && typeof options.imagefilters === 'object') {
       var filterQuery = '';
       var filters = Object.keys(options.imagefilters);
@@ -229,7 +236,7 @@ Bing.prototype.images = function(query, callback, options) {
       });
       options.imagefilters = filterQuery;
     }
-    this.searchVertical(query, "Image", callback, options);
+    this.searchVertical(query, "Image", options, callback);
 };
 
 function capitalizeFirstLetter(s) {
@@ -237,4 +244,3 @@ function capitalizeFirstLetter(s) {
 }
 
 module.exports = Bing;
-

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.9.5",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.10.0",
+    "grunt-jsbeautifier": "~0.2.10",
     "grunt-jsdoc": "^0.5.7",
     "grunt-simple-mocha": "^0.4.0",
     "mocha": "^1.21.4",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,31 +1,28 @@
 var validWebResponse = {
-  "d": {
-      "results": [
-          {
-              "__metadata": {
-                  "uri": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=0&$top=1",
-                  "type": "WebResult"
-              },
-              "ID": "26888c2a-d245-47dc-87de-dc3551249de7",
-              "Title": "Xbox | Games and Entertainment on All Your Devices",
-              "Description": "Experience the new generation of games and entertainment with Xbox. Play Xbox games and stream video on all your devices.",
-              "DisplayUrl": "www.xbox.com",
-              "Url": "http://www.xbox.com/"
-          },
-          {
-              "__metadata": {
-                  "uri": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=1&$top=1",
-                  "type": "WebResult"
-              },
-              "ID": "ff23e110-31c2-44f9-be21-f213bcd4c654",
-              "Title": "Amazon.com: Xbox - More Systems: Video Games: Games ...",
-              "Description": "Online shopping for Video Games from a great selection of Games, Hardware, Computer And Console Video Game Products & more at everyday low prices.",
-              "DisplayUrl": "www.amazon.com/Xbox-Games/b?ie=UTF8&node=537504",
-              "Url": "http://www.amazon.com/Xbox-Games/b?ie=UTF8&node=537504"
-          }
-      ],
-      "__next": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=2"
-  }
+    "d": {
+        "results": [{
+            "__metadata": {
+                "uri": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=0&$top=1",
+                "type": "WebResult"
+            },
+            "ID": "26888c2a-d245-47dc-87de-dc3551249de7",
+            "Title": "Xbox | Games and Entertainment on All Your Devices",
+            "Description": "Experience the new generation of games and entertainment with Xbox. Play Xbox games and stream video on all your devices.",
+            "DisplayUrl": "www.xbox.com",
+            "Url": "http://www.xbox.com/"
+        }, {
+            "__metadata": {
+                "uri": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=1&$top=1",
+                "type": "WebResult"
+            },
+            "ID": "ff23e110-31c2-44f9-be21-f213bcd4c654",
+            "Title": "Amazon.com: Xbox - More Systems: Video Games: Games ...",
+            "Description": "Online shopping for Video Games from a great selection of Games, Hardware, Computer And Console Video Game Products & more at everyday low prices.",
+            "DisplayUrl": "www.amazon.com/Xbox-Games/b?ie=UTF8&node=537504",
+            "Url": "http://www.amazon.com/Xbox-Games/b?ie=UTF8&node=537504"
+        }],
+        "__next": "https://api.datamarket.azure.com/Data.ashx/Bing/Search/Web?Query='xbox'&$skip=2"
+    }
 };
 
 var should = require('should'),
@@ -34,7 +31,7 @@ var should = require('should'),
     request = require('request'),
     bing = require('../lib/bing');
 
-describe('Bing', function() {
+describe('Bing', function () {
     var server;
     var app;
     var port = 4321;
@@ -43,13 +40,14 @@ describe('Bing', function() {
         app = express();
         server = http.createServer(app);
         server.listen.apply(server, [port,
-            function(err, result) {
+            function (err, result) {
                 if (err) {
                     done(err);
                 } else {
                     done();
                 }
-            }]);
+            }
+        ]);
     });
 
     after(function (done) {
@@ -59,11 +57,14 @@ describe('Bing', function() {
         done();
     });
 
-    it('should cope with valid responses', function(done) {
+    it('should cope with valid responses', function (done) {
         app.get('/hello/Web', function (req, res) {
             res.status(200).send(JSON.stringify(validWebResponse));
         });
-        var bingClient = bing({ rootUri: 'http://localhost:'+port+'/hello/', accKey: '123' });
+        var bingClient = bing({
+            rootUri: 'http://localhost:' + port + '/hello/',
+            accKey: '123'
+        });
         bingClient.search('xbox', function (error, response, body) {
             response.statusCode.should.eql(200);
             body.should.eql(validWebResponse);
@@ -71,13 +72,18 @@ describe('Bing', function() {
         });
     });
 
-    it('should cope with errors', function(done) {
+    it('should cope with errors', function (done) {
         // No actual data on what the failure looks like.
-        var failure = { message: 'Failed request' };
+        var failure = {
+            message: 'Failed request'
+        };
         app.get('/hello/Image', function (req, res) {
-           res.status(500).send(failure);
+            res.status(500).send(failure);
         });
-        var bingClient = bing({ rootUri: 'http://localhost:'+port+'/hello/', accKey: '123' });
+        var bingClient = bing({
+            rootUri: 'http://localhost:' + port + '/hello/',
+            accKey: '123'
+        });
         bingClient.images('xbox', function (error, response, body) {
             response.statusCode.should.eql(500);
             body.should.eql(JSON.stringify(failure));

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,128 +1,133 @@
-
 // Try to get an access key to run all this test.
 // If the file doesn't exist or it doesn't contain an access key, it
 // should still run the basic tests; thus throwing an exception must
 // be avoided.
-try{
-  var accKey = require('./secrets').accKey;
-}
-catch(e){ console.log(e); }
-
-if(!accKey){
-  return console.error("Need to include an access key in your secrets.js");
+try {
+    var accKey = require('./secrets').accKey;
+} catch (e) {
+    console.log(e);
 }
 
+if (!accKey) {
+    return console.error("Need to include an access key in your secrets.js");
+}
 
-var Bing = require('../')({ accKey: accKey});
+
+var Bing = require('../')({
+    accKey: accKey
+});
 var should = require('should');
 
 
-describe("Bing Search", function(){
+describe("Bing Search", function () {
 
-  this.timeout(1000 * 10);
+    this.timeout(1000 * 10);
 
-  it('works without options', function(done){
+    it('works without options', function (done) {
 
-    Bing.search('monkey vs frog', function(err, res, body){
+        Bing.search('monkey vs frog', function (err, res, body) {
 
-      should.not.exist(err);
-      should.exist(res);
-      should.exist(body);
+            should.not.exist(err);
+            should.exist(res);
+            should.exist(body);
 
-      body.d.results.should.have.length(50);
+            body.d.results.should.have.length(50);
 
-      //TODO check it contains the right fields
-      done();
+            //TODO check it contains the right fields
+            done();
+        });
     });
-  });
 
-  it('finds only 5 results', function(done){
-    Bing.search('monkey vs frog', {
-          top: 5,
-          market: 'en-US',
-          adult: 'Strict'
-    }, function(err, res, body){
-      should.not.exist(err);
-      should.exist(res);
-      should.exist(body);
+    it('finds only 5 results', function (done) {
+        Bing.search('monkey vs frog', {
+            top: 5,
+            market: 'en-US',
+            adult: 'Strict'
+        }, function (err, res, body) {
+            should.not.exist(err);
+            should.exist(res);
+            should.exist(body);
 
-      body.d.results.should.have.length(5);
+            body.d.results.should.have.length(5);
 
-      done();
+            done();
+        });
     });
-  });
 
 });
 
 
-describe("Bing Images", function(){
+describe("Bing Images", function () {
 
-  this.timeout(1000 * 10);
+    this.timeout(1000 * 10);
 
-  it('finds images with specific options', function(done){
-    Bing.images('pizza', {
-          top: 3,
-          adult: 'Off',
-          imagefilters: { size: 'small', color: 'monochrome' }
-    }, function(err, res, body){
-      should.not.exist(err);
-      should.exist(res);
-      should.exist(body);
+    it('finds images with specific options', function (done) {
+        Bing.images('pizza', {
+            top: 3,
+            adult: 'Off',
+            imagefilters: {
+                size: 'small',
+                color: 'monochrome'
+            }
+        }, function (err, res, body) {
+            should.not.exist(err);
+            should.exist(res);
+            should.exist(body);
 
-      body.d.results.should.have.length(3);
+            body.d.results.should.have.length(3);
 
-      done();
+            done();
+        });
     });
-  });
 
 });
 
 
-describe("Bing News", function(){
+describe("Bing News", function () {
 
-  this.timeout(1000 * 10);
+    this.timeout(1000 * 10);
 
-  it('finds news with specific options', function(done){
+    it('finds news with specific options', function (done) {
 
-    Bing.news('ps4', {
-          top: 10,
-          skip: 1,
-          newsortby: 'Date'
-    }, function(err, res, body){
-      //TODO try unaccepted options like imagefilters
+        Bing.news('ps4', {
+            top: 10,
+            skip: 1,
+            newsortby: 'Date'
+        }, function (err, res, body) {
+            //TODO try unaccepted options like imagefilters
 
-      should.not.exist(err);
-      should.exist(res);
-      should.exist(body);
+            should.not.exist(err);
+            should.exist(res);
+            should.exist(body);
 
-      body.d.results.should.have.length(10);
+            body.d.results.should.have.length(10);
 
-      done();
+            done();
+        });
     });
-  });
 
 });
 
 
-describe("Bing Video", function(){
+describe("Bing Video", function () {
 
-  this.timeout(1000 * 10);
+    this.timeout(1000 * 10);
 
-  it('finds videos with specific options', function(done){
+    it('finds videos with specific options', function (done) {
 
-    Bing.video('monkey vs frog', {
-          top: 10
-    }, function(err, res, body){
-      should.not.exist(err);
-      should.exist(res);
-      should.exist(body);
+        Bing.video('monkey vs frog', {
+            top: 10
+        }, function (err, res, body) {
+            should.not.exist(err);
+            should.exist(res);
+            should.exist(body);
 
-      body.d.results.should.have.length(10);
+            body.d.results.should.have.length(10);
 
-      //TODO try here unaccepted options like imagefilters
+            //TODO try here unaccepted options like imagefilters
 
-      done();
+            done();
+        });
     });
-  });
 
 });

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,15 +6,15 @@
 try{
   var accKey = require('./secrets').accKey;
 }
-catch(e){ console.log(e) }
+catch(e){ console.log(e); }
 
 if(!accKey){
   return console.error("Need to include an access key in your secrets.js");
-} 
+}
 
 
-var Bing = require('../')({ accKey: accKey})
-  , should = require('should')
+var Bing = require('../')({ accKey: accKey});
+var should = require('should');
 
 
 describe("Bing Search", function(){
@@ -23,7 +23,7 @@ describe("Bing Search", function(){
 
   it('works without options', function(done){
 
-    Bing.search('nigger vs chink', function(err, res, body){
+    Bing.search('monkey vs frog', function(err, res, body){
 
       should.not.exist(err);
       should.exist(res);
@@ -37,8 +37,11 @@ describe("Bing Search", function(){
   });
 
   it('finds only 5 results', function(done){
-    Bing.search('nigger vs chink', function(err, res, body){
-
+    Bing.search('monkey vs frog', {
+          top: 5,
+          market: 'en-US',
+          adult: 'Strict'
+    }, function(err, res, body){
       should.not.exist(err);
       should.exist(res);
       should.exist(body);
@@ -46,14 +49,9 @@ describe("Bing Search", function(){
       body.d.results.should.have.length(5);
 
       done();
-    },
-    {
-      top: 5,
-      market: 'en-US',
-      adult: 'Strict'
     });
   });
-  
+
 });
 
 
@@ -62,9 +60,11 @@ describe("Bing Images", function(){
   this.timeout(1000 * 10);
 
   it('finds images with specific options', function(done){
-    Bing.images('pizza',
-                function(err, res, body){
-
+    Bing.images('pizza', {
+          top: 3,
+          adult: 'Off',
+          imagefilters: { size: 'small', color: 'monochrome' }
+    }, function(err, res, body){
       should.not.exist(err);
       should.exist(res);
       should.exist(body);
@@ -72,14 +72,9 @@ describe("Bing Images", function(){
       body.d.results.should.have.length(3);
 
       done();
-    },
-    {
-      top: 3,
-      adult: 'Off',
-      imagefilters: { size: 'small', color: 'monochrome' }
     });
   });
-    
+
 });
 
 
@@ -89,7 +84,11 @@ describe("Bing News", function(){
 
   it('finds news with specific options', function(done){
 
-    Bing.news('ps4', function(err, res, body){
+    Bing.news('ps4', {
+          top: 10,
+          skip: 1,
+          newsortby: 'Date'
+    }, function(err, res, body){
       //TODO try unaccepted options like imagefilters
 
       should.not.exist(err);
@@ -99,14 +98,9 @@ describe("Bing News", function(){
       body.d.results.should.have.length(10);
 
       done();
-    },
-    {
-      top: 10,
-      skip: 1,
-      newsortby: 'Date'
     });
   });
-    
+
 });
 
 
@@ -116,8 +110,9 @@ describe("Bing Video", function(){
 
   it('finds videos with specific options', function(done){
 
-    Bing.video('monkey vs frog', function(err, res, body){
-
+    Bing.video('monkey vs frog', {
+          top: 10
+    }, function(err, res, body){
       should.not.exist(err);
       should.exist(res);
       should.exist(body);
@@ -127,11 +122,7 @@ describe("Bing Video", function(){
       //TODO try here unaccepted options like imagefilters
 
       done();
-    },
-    {
-      top: 10
     });
   });
-    
-});
 
+});


### PR DESCRIPTION
Standard node.js best practices are to have the callback be the last parameter. This is especially important when using modified control flow (as is used by [co](https://github.com/tj/co) or [koa](http://koajs.com)).

When using koa, having the final parameter be the callback allows us to promisify the library:
```
global.Promise = require('bluebird').Promise;
var Bing = Promise.promisifyAll(require('node-bing-api')({
    'accKey': config.bingAccKey
}));
```
This then lets us `yield` the function call:
```
var results = yield Bing.imagesAsync(args.query, {'adult': 'Moderate'});
var body = results[1];
```

As this is a fairly significant breaking change, this will likely have to go out as a 2.0.0 release.

I also added a jsbeautify grunt task to help with code readability and consistency.