### PR TITLE
Fix typo when constructing query string

### DIFF
--- a/lib/bing.js
+++ b/lib/bing.js
@@ -66,7 +66,7 @@ var Bing = function (options) {
     + vertical
     + (vertical == 'spellcheck' ? "?text=" : "?q=") + query
     + (opts.top ? "&count=" + opts.top : "")
-    + (opts.offset ? "&offset=" + opts.skip : "")
+    + (opts.skip ? "&offset=" + opts.skip : "")
     + (opts.preContextText ? "&preContextText=" + opts.preContextText : "")
     + (opts.mode ? "&mode=" + opts.mode : "")
     + (opts.postContextText ? "&postContextText=" + opts.postContextText : "")


### PR DESCRIPTION
(I think) opts.offset should be opts.skip consistent with adjacent lines (and the docs)

Currently the ‘skip’ parameter doesn’t work as expected when used like this:

Bing.images("Ninja Turtles", {top:3,skip:2}, function(error, result, body){
      console.log(body.value);
    }

or this:

Bing.images("Ninja Turtles", {top:3,offset:2}, function(error, result, body){
      console.log(body.value);
    }

but this works:

Bing.images("Ninja Turtles", {top:3,skip:2,offset:2}, function(error, result, body){
      console.log(body.value);
    }