### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ from the provided `secrets.js.example` example, and fill it in with a valid acce
 
 Then just `mocha`.
 
+Test on [RapidAPI](https://rapidapi.com/package/BingSearch?utm_source=BingGitHub&utm_medium=button)
 
 ## License
 MIT


### PR DESCRIPTION
I've added a link in your README to Bing's functions page in RapidAPI. I've done this for a few Bing SDKs to help those who are reading the READMEs, understand and test the API before use.