### PR TITLE
fixes http 400 bad request errors

### DIFF
--- a/lib/bing.js
+++ b/lib/bing.js
@@ -86,6 +86,8 @@ var Bing = function (options) {
     var qStr = qs.stringify(queryOpts);
 
     reqUri += qStr ? '&' + qStr : '';
+    
+    reqUri = encodeURI(reqUri);
 
     request({
       uri: reqUri,


### PR DESCRIPTION
I noticed that searching on text with special characters seems to cause HTTP 400 errors.  For example:

Jakub CzerwiÅ„ski

```
Error: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Bad Request</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Bad Request - Invalid URL</h2>
<hr><p>HTTP Error 400. The request URL is invalid.</p>
</BODY></HTML>

    at Request._callback (/Users/jritsema/code/viddb/node_modules/node-bing-api/lib/bing.js:105:17)
    at Request.self.callback (/Users/jritsema/code/viddb/node_modules/request/request.js:188:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/Users/jritsema/code/viddb/node_modules/request/request.js:1171:10)
    at emitOne (events.js:96:13)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/Users/jritsema/code/viddb/node_modules/request/request.js:1091:12)
    at IncomingMessage.g (events.js:291:16)
    at emitNone (events.js:91:20)```