### PR TITLE
Update rootUri to API V7

### DIFF
--- a/lib/bing.js
+++ b/lib/bing.js
@@ -21,7 +21,7 @@ var Bing = function (options) {
   var defaults = {
 
     //Bing Search API URI
-    rootUri: "https://api.cognitive.microsoft.com/bing/v5.0/",
+    rootUri: "https://api.cognitive.microsoft.com/bing/v7.0/",
 
     //Account Key
     accKey: null,


### PR DESCRIPTION
line 19: change rootUri from v5.0 to v7.0

Tried using this package as is and got a 401 error, changed it and it worked.