### PR TITLE
Update API endpoint

### DIFF
--- a/lib/bing.js
+++ b/lib/bing.js
@@ -21,7 +21,7 @@ var Bing = function (options) {
   var defaults = {
 
     //Bing Search API URI
-    rootUri: "https://api.cognitive.microsoft.com/bing/v7.0/",
+    rootUri: "https://api.cognitive.microsoft.com/bing/v7.0/search",
 
     //Account Key
     accKey: null,


### PR DESCRIPTION
It seems that the API endpoint has been changed by Microsoft and as a result, I think the root URI in "bing.js" needs to be updated from "https://api.cognitive.microsoft.com/bing/v7.0/" to "https://api.bing.microsoft.com/v7.0/search". I have included their description here: "Bing Search APIs are moving from Cognitive Services to Bing Search Services. Starting October 30, 2020, any new instances of Bing Search need to be provisioned following the process documented here."